### PR TITLE
Parse hash with symbols as keys

### DIFF
--- a/lib/json-api-vanilla/parser.rb
+++ b/lib/json-api-vanilla/parser.rb
@@ -175,7 +175,7 @@ module JSON::Api::Vanilla
   def self.naive_validate(hash)
     root_keys = %w(data errors meta)
     present_structures = root_keys.map do |key|
-      obj = hash[key]
+      obj = hash[key] || hash[key.to_sym]
       obj.respond_to?(:empty?) ? !obj.empty? : !!obj
     end
     if present_structures.none?

--- a/spec/json-api-vanilla/diff_spec.rb
+++ b/spec/json-api-vanilla/diff_spec.rb
@@ -85,4 +85,10 @@ describe JSON::Api::Vanilla do
       JSON::Api::Vanilla.parse(json)
     end.to raise_error(JSON::Api::Vanilla::InvalidRootStructure)
   end
+
+  it "should not raise any errors if the document contains root elements as symbols" do
+    expect do
+      JSON::Api::Vanilla.naive_validate(data: { id: 1, type: 'mvp' })
+    end.to_not raise_error
+  end
 end


### PR DESCRIPTION
Since the library allows parsing json:api docs from a hash, we need to
allow for a possibility that hash keys might be symbols. The parser
itself behaves correctly, but the naive validation was too naive.