### PR TITLE
Wrong namespacing when class already exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 Gemfile.lock
 .ruby-version
 .rvmrc
+.idea
 *.gem

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,6 @@ source "http://rubygems.org"
 gemspec
 
 group :test do
+  gem 'rspec'
   gem 'rake'
 end

--- a/lib/json-api-vanilla/parser.rb
+++ b/lib/json-api-vanilla/parser.rb
@@ -115,7 +115,7 @@ module JSON::Api::Vanilla
 
   def self.prepare_class(hash, superclass, container)
     name = ruby_class_name(hash['type']).to_sym
-    if container.const_defined?(name)
+    if container.constants.include?(name)
       klass = container.const_get(name)
     else
       klass = generate_object(name, superclass, container)

--- a/spec/json-api-vanilla/diff_spec.rb
+++ b/spec/json-api-vanilla/diff_spec.rb
@@ -97,4 +97,21 @@ describe JSON::Api::Vanilla do
       JSON::Api::Vanilla.naive_validate(data: [])
     end.to_not raise_error
   end
+
+  describe '.prepare_class' do
+    let(:container) {Module.new}
+    let(:superclass) {Class.new}
+    let(:hash) {{'type' => 'test-classes'}}
+    subject {described_class.prepare_class(hash, superclass, container)}
+
+    context 'when same name class in global scope' do
+      class TestClasses
+      end
+
+      it 'should create dynamic class in container' do
+        subject
+        expect(container.constants).to include(:TestClasses)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This commit fix the namespacing failing with existing classes.
Basically if you ask const_defined? on a Module.new you get also the defined classes of the ancestors.
So we changed it to lookup only through the constants of the container Module.