### PR TITLE
Create a links object on each resource

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@ gemspec
 
 group :test do
   gem 'rake'
+  gem 'rspec'
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# JSON API *VANILLA*
+# JSON API _VANILLA_
 
-Deserialize JSON API formats into *vanilla* Ruby objects.
+Deserialize JSON API formats into _vanilla_ Ruby objects.
 The simplest JSON API library at all altitudes above Earth centre.
 
 ```ruby
@@ -38,13 +38,14 @@ fields:
 - `errors` is an array containing [errors](http://jsonapi.org/format/#error-objects). Each error is a Hash.
 - `links` is a Hash from objects (obtained from `data`) to their links, as a
   Hash.
+  - A `links` Hash is also included as an attribute on each `data` object (ie `data.links` or `data[0].links`).
 - `rel_links` is a Hash from objects' relationships (obtained from `data`) to
   the links defined in that relationship, as a Hash.
 - `meta` is a Hash from objects to their meta information (a Hash).
 - `find('type', 'id')` returns the object with that type and that id.
 - `find_all('type')` returns an Array of all objects with that type.
 - `keys` is a Hash from objects to a Hash from their original field names
-  (non-snake\_case'd) to the corresponding object.
+  (non-snake_case'd) to the corresponding object.
 
 # License
 

--- a/lib/json-api-vanilla/parser.rb
+++ b/lib/json-api-vanilla/parser.rb
@@ -39,10 +39,10 @@ module JSON::Api::Vanilla
 
     data_hash = hash['data']
     data_hash_array = if data_hash.is_a?(Array)
-      data_hash
-    else
-      [data_hash].compact
-    end
+                        data_hash
+                      else
+                        [data_hash].compact
+                      end
     obj_hashes = (hash['included'] || []) + data_hash_array
     errors = hash['errors']
 
@@ -68,6 +68,7 @@ module JSON::Api::Vanilla
       end
       if o_hash['links']
         links[obj] = o_hash['links']
+        set_key(obj, 'links', o_hash['links'], original_keys)
       end
       objects[[obj.type, obj.id]] = obj
     end
@@ -100,17 +101,17 @@ module JSON::Api::Vanilla
 
     # Create the main object.
     data = if data_hash.is_a?(Array)
-      data_hash.map do |o_hash|
-        objects[[o_hash['type'], o_hash['id']]]
-      end
-    elsif data_hash
-      objects[[data_hash['type'], data_hash['id']]]
-    end
+             data_hash.map do |o_hash|
+               objects[[o_hash['type'], o_hash['id']]]
+             end
+           elsif data_hash
+             objects[[data_hash['type'], data_hash['id']]]
+           end
     links[data] = hash['links']
     meta[data] = hash['meta']
     Document.new(data, links: links, rel_links: rel_links, meta: meta,
-                 objects: objects, keys: original_keys, errors: errors,
-                 container: container, superclass: superclass)
+                       objects: objects, keys: original_keys, errors: errors,
+                       container: container, superclass: superclass)
   end
 
   def self.prepare_class(hash, superclass, container)
@@ -122,6 +123,7 @@ module JSON::Api::Vanilla
     end
     add_accessor(klass, 'id')
     add_accessor(klass, 'type')
+    add_accessor(klass, 'links')
     attr_keys = hash['attributes'] ? hash['attributes'].keys : []
     rel_keys = hash['relationships'] ? hash['relationships'].keys : []
     (attr_keys + rel_keys).each do |key|
@@ -162,9 +164,9 @@ module JSON::Api::Vanilla
   # identifier.
   def self.ruby_ident_name(name)
     name.gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
-       .gsub(/([a-z\d])([A-Z])/,'\1_\2')
-       .tr("-", "_")
-       .downcase
+      .gsub(/([a-z\d])([A-Z])/,'\1_\2')
+      .tr("-", "_")
+      .downcase
   end
 
   # Naïvely validate the top level document structure
@@ -198,8 +200,8 @@ module JSON::Api::Vanilla
     attr_reader :container
     attr_reader :superclass
     def initialize(data, links: {}, rel_links: {}, meta: {},
-                   keys: {}, objects: {}, errors: [],
-                   container: Module.new, superclass: Class.new)
+                         keys: {}, objects: {}, errors: [],
+                         container: Module.new, superclass: Class.new)
       @data = data
       @links = links
       @rel_links = rel_links

--- a/lib/json-api-vanilla/parser.rb
+++ b/lib/json-api-vanilla/parser.rb
@@ -39,10 +39,10 @@ module JSON::Api::Vanilla
 
     data_hash = hash['data']
     data_hash_array = if data_hash.is_a?(Array)
-                        data_hash
-                      else
-                        [data_hash].compact
-                      end
+      data_hash
+    else
+      [data_hash].compact
+    end
     obj_hashes = (hash['included'] || []) + data_hash_array
     errors = hash['errors']
 
@@ -101,17 +101,17 @@ module JSON::Api::Vanilla
 
     # Create the main object.
     data = if data_hash.is_a?(Array)
-             data_hash.map do |o_hash|
-               objects[[o_hash['type'], o_hash['id']]]
-             end
-           elsif data_hash
-             objects[[data_hash['type'], data_hash['id']]]
-           end
+      data_hash.map do |o_hash|
+        objects[[o_hash['type'], o_hash['id']]]
+      end
+    elsif data_hash
+      objects[[data_hash['type'], data_hash['id']]]
+    end
     links[data] = hash['links']
     meta[data] = hash['meta']
     Document.new(data, links: links, rel_links: rel_links, meta: meta,
-                       objects: objects, keys: original_keys, errors: errors,
-                       container: container, superclass: superclass)
+                 objects: objects, keys: original_keys, errors: errors,
+                 container: container, superclass: superclass)
   end
 
   def self.prepare_class(hash, superclass, container)
@@ -164,9 +164,9 @@ module JSON::Api::Vanilla
   # identifier.
   def self.ruby_ident_name(name)
     name.gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
-      .gsub(/([a-z\d])([A-Z])/,'\1_\2')
-      .tr("-", "_")
-      .downcase
+       .gsub(/([a-z\d])([A-Z])/,'\1_\2')
+       .tr("-", "_")
+       .downcase
   end
 
   # Naïvely validate the top level document structure
@@ -200,8 +200,8 @@ module JSON::Api::Vanilla
     attr_reader :container
     attr_reader :superclass
     def initialize(data, links: {}, rel_links: {}, meta: {},
-                         keys: {}, objects: {}, errors: [],
-                         container: Module.new, superclass: Class.new)
+                   keys: {}, objects: {}, errors: [],
+                   container: Module.new, superclass: Class.new)
       @data = data
       @links = links
       @rel_links = rel_links

--- a/lib/json-api-vanilla/version.rb
+++ b/lib/json-api-vanilla/version.rb
@@ -2,7 +2,7 @@
 module JSON
   module Api
     module Vanilla
-      VERSION = '1.0.1'
+      VERSION = '1.1.0'
     end
   end
 end

--- a/spec/json-api-vanilla/diff_spec.rb
+++ b/spec/json-api-vanilla/diff_spec.rb
@@ -97,4 +97,27 @@ describe JSON::Api::Vanilla do
       JSON::Api::Vanilla.naive_validate(data: [])
     end.to_not raise_error
   end
+
+  it "should include resources links on the data object" do
+    expect(doc.data[0].links["self"]).to eql("http://example.com/articles/1")
+  end
+
+  it "should include resource links when the data object is not an array" do
+    json = <<-JSON
+    {
+      "data": {
+        "type": "articles",
+        "id": "1",
+        "attributes": {
+          "title": "JSON API paints my bikeshed!"
+        },
+        "links": {
+          "self": "http://example.com/articles/1"
+        }
+      }
+    }
+    JSON
+    doc = JSON::Api::Vanilla.parse(json)
+    expect(doc.data.links["self"]).to eql("http://example.com/articles/1")
+  end
 end


### PR DESCRIPTION
Add the ability to access resource links through `doc.data[0].links` in addition to `doc.links[doc.data[0]]`. This also makes links work when data is a single resource instead of an array. 