### PR TITLE
Fix relationships of included objects

### DIFF
--- a/lib/json-api-vanilla/parser.rb
+++ b/lib/json-api-vanilla/parser.rb
@@ -77,12 +77,22 @@ module JSON::Api::Vanilla
             if data.is_a?(Array)
               # One-to-many relationship.
               ref = data.map do |ref_hash|
-                klass = prepare_class(ref_hash, superclass, container)
-                objects[[ref_hash['type'], ref_hash['id']]] || prepare_object(ref_hash, klass)
+                _ref = objects[[ref_hash['type'], ref_hash['id']]]
+
+                if _ref.nil?
+                  klass = prepare_class(ref_hash, superclass, container)
+                  _ref = prepare_object(ref_hash, klass)
+                end
+
+                _ref
               end
             else
-              klass = prepare_class(data, superclass, container)
-              ref = objects[[data['type'], data['id']]] || prepare_object(data, klass)
+              ref = objects[[data['type'], data['id']]]
+
+              if ref.nil?
+                klass = prepare_class(data, superclass, container)
+                ref = prepare_object(data, klass)
+              end
             end
           end
 

--- a/lib/json-api-vanilla/parser.rb
+++ b/lib/json-api-vanilla/parser.rb
@@ -78,11 +78,11 @@ module JSON::Api::Vanilla
               # One-to-many relationship.
               ref = data.map do |ref_hash|
                 klass = prepare_class(ref_hash, superclass, container)
-                objects[[ref_hash['type'], ref_hash['id']]] || prepare_object(ref_hash, klass, original_keys)
+                objects[[ref_hash['type'], ref_hash['id']]] || prepare_object(ref_hash, klass)
               end
             else
               klass = prepare_class(data, superclass, container)
-              ref = objects[[data['type'], data['id']]] || prepare_object(data, klass, original_keys)
+              ref = objects[[data['type'], data['id']]] || prepare_object(data, klass)
             end
           end
 
@@ -127,7 +127,7 @@ module JSON::Api::Vanilla
     klass
   end
 
-  def self.prepare_object(hash, klass, original_keys)
+  def self.prepare_object(hash, klass, original_keys = {})
     (klass.new).tap do |obj|
       obj.type = hash['type']
       obj.id = hash['id']

--- a/lib/json-api-vanilla/parser.rb
+++ b/lib/json-api-vanilla/parser.rb
@@ -58,17 +58,12 @@ module JSON::Api::Vanilla
 
     obj_hashes.each do |o_hash|
       klass = prepare_class(o_hash, superclass, container)
-      obj = klass.new
-      obj.type = o_hash['type']
-      obj.id = o_hash['id']
-      if o_hash['attributes']
-        o_hash['attributes'].each do |key, value|
-          set_key(obj, key, value, original_keys)
-        end
-      end
+      obj = prepare_object(o_hash, klass, original_keys)
+
       if o_hash['links']
         links[obj] = o_hash['links']
       end
+
       objects[[obj.type, obj.id]] = obj
     end
 
@@ -82,10 +77,12 @@ module JSON::Api::Vanilla
             if data.is_a?(Array)
               # One-to-many relationship.
               ref = data.map do |ref_hash|
-                objects[[ref_hash['type'], ref_hash['id']]]
+                klass = prepare_class(ref_hash, superclass, container)
+                objects[[ref_hash['type'], ref_hash['id']]] || prepare_object(ref_hash, klass, original_keys)
               end
             else
-              ref = objects[[data['type'], data['id']]]
+              klass = prepare_class(data, superclass, container)
+              ref = objects[[data['type'], data['id']]] || prepare_object(data, klass, original_keys)
             end
           end
 
@@ -128,6 +125,18 @@ module JSON::Api::Vanilla
       add_accessor(klass, key)
     end
     klass
+  end
+
+  def self.prepare_object(hash, klass, original_keys)
+    (klass.new).tap do |obj|
+      obj.type = hash['type']
+      obj.id = hash['id']
+      if hash['attributes']
+        hash['attributes'].each do |key, value|
+          set_key(obj, key, value, original_keys)
+        end
+      end
+    end
   end
 
   def self.generate_object(ruby_name, superclass, container)

--- a/spec/json-api-vanilla/diff_spec.rb
+++ b/spec/json-api-vanilla/diff_spec.rb
@@ -122,4 +122,24 @@ describe JSON::Api::Vanilla do
       end
     end
   end
+
+  describe '.prepare_object' do
+    let(:data) do
+      {
+        'type' => 'example',
+        'id' => '1',
+        'attributes' => {
+          'name' => 'example name'
+        }
+      }
+    end
+    let(:klass) { described_class.prepare_class(data, Class.new, Module.new) }
+    subject { described_class.prepare_object(data, klass) }
+
+    it 'creates an object with the attributes mapped' do
+      expect(subject.type).to eql(data['type'])
+      expect(subject.id).to eql(data['id'])
+      expect(subject.name).to eql(data['attributes']['name'])
+    end
+  end
 end

--- a/spec/json-api-vanilla/diff_spec.rb
+++ b/spec/json-api-vanilla/diff_spec.rb
@@ -20,6 +20,14 @@ describe JSON::Api::Vanilla do
     expect(doc.links[doc.data]['self']).to eql("http://example.com/articles")
   end
 
+  it "should read objects that are only in relationships of included" do
+    expect(doc.data.first.comments.first.post.id).to eql("42")
+  end
+
+  it "should read objects that are only in relationships of included when it is an array" do
+    expect(doc.data.first.comments.first.tags[0].id).to eql("42")
+  end
+
   it "should find objects by type and id" do
     expect(doc.find('comments', '5').body).to eql("First!")
   end

--- a/spec/json-api-vanilla/example.json
+++ b/spec/json-api-vanilla/example.json
@@ -56,6 +56,17 @@
     "relationships": {
       "author": {
         "data": { "type": "people", "id": "2" }
+      },
+      "tags": {
+        "data": [
+          { "type": "tag", "id": "42" }
+        ]
+      },
+      "post": {
+        "data": {
+          "type": "post",
+          "id": "42"
+        }
       }
     },
     "links": {


### PR DESCRIPTION
If an object was present only in the relationships of an included object and not in the root of the data object or the included object it was not being parsed correctly.