### PR TITLE
Don’t build empty objects on missing linked resources.

### DIFF
--- a/lib/json-api-vanilla/parser.rb
+++ b/lib/json-api-vanilla/parser.rb
@@ -72,6 +72,9 @@ module JSON::Api::Vanilla
       obj = objects[[o_hash['type'], o_hash['id']]]
       if o_hash['relationships']
         o_hash['relationships'].each do |key, value|
+          # Instantiate ref initially
+          ref = nil
+
           if value['data']
             data = value['data']
             if data.is_a?(Array)
@@ -96,7 +99,6 @@ module JSON::Api::Vanilla
             end
           end
 
-          ref = ref || Object.new
           set_key(obj, key, ref, original_keys)
 
           rel_links[ref] = value['links']

--- a/lib/json-api-vanilla/version.rb
+++ b/lib/json-api-vanilla/version.rb
@@ -2,7 +2,7 @@
 module JSON
   module Api
     module Vanilla
-      VERSION = '1.0.2'
+      VERSION = '1.0.3'
     end
   end
 end


### PR DESCRIPTION
According to the Spec (https://jsonapi.org/format/#document-resource-object-linkage), empty relationships are null by default. Object.new is roughly equal to an empty JSON ({}) in context of this deserializer. It is hard for us to recognize missing or non-present relationships if we have an object with no attributes. To avoid this, instead of a PORO, just nil is returned as reference to a non-present relationships.