### PR TITLE
Validate relationship objects according to json:api required fields

### DIFF
--- a/lib/json-api-vanilla/parser.rb
+++ b/lib/json-api-vanilla/parser.rb
@@ -72,6 +72,8 @@ module JSON::Api::Vanilla
       obj = objects[[o_hash['type'], o_hash['id']]]
       if o_hash['relationships']
         o_hash['relationships'].each do |key, value|
+          naive_validate_relationship_object(value)
+
           if value['data']
             data = value['data']
             if data.is_a?(Array)
@@ -195,6 +197,18 @@ module JSON::Api::Vanilla
     present_structures = root_keys & hash.keys.map(&:to_sym)
     if present_structures.empty?
       raise InvalidRootStructure.new("JSON:API document must contain at least one of these objects: #{root_keys.join(', ')}")
+    end
+  end
+
+  # Naïvely validate a relationship object.
+  # @param hash [Hash] json:api document as a hash
+  # @raise [InvalidRootStructure] raised if the document doesn't have data, errors nor meta objects
+  # at its root.
+  def self.naive_validate_relationship_object(hash)
+    root_keys = %i(data meta links)
+    present_structures = root_keys & hash.keys.map(&:to_sym)
+    if present_structures.empty?
+      raise InvalidRootStructure.new("JSON:API relationship must contain at least one of these objects: #{root_keys.join(', ')}")
     end
   end
 

--- a/spec/json-api-vanilla/diff_spec.rb
+++ b/spec/json-api-vanilla/diff_spec.rb
@@ -94,6 +94,35 @@ describe JSON::Api::Vanilla do
     end.to raise_error(JSON::Api::Vanilla::InvalidRootStructure)
   end
 
+  it "should raise an error if the document contains an unrecognized element" do
+    json = <<-JSON
+    {
+      "type": "object",
+      "id": "123",
+      "attributes": {},
+      "foo": "bar"
+    }
+    JSON
+    expect do
+      JSON::Api::Vanilla.parse(json)
+    end.to raise_error(JSON::Api::Vanilla::InvalidRootStructure)
+  end
+
+  it "should raise an error if the document has a malformed link" do
+    json = <<-JSON
+    {
+      "data": {
+        "type": "cycle",
+        "id": "1",
+        "relationships": { "cycle": { "type": "cycle", "id": "2" } }
+      }
+    }
+    JSON
+    expect do
+      JSON::Api::Vanilla.parse(json)
+    end.to raise_error(JSON::Api::Vanilla::InvalidRootStructure)
+  end
+
   it "should not raise any errors if the document contains root elements as symbols" do
     expect do
       JSON::Api::Vanilla.naive_validate(data: { id: 1, type: 'mvp' })

--- a/spec/json-api-vanilla/diff_spec.rb
+++ b/spec/json-api-vanilla/diff_spec.rb
@@ -108,7 +108,7 @@ describe JSON::Api::Vanilla do
     end.to raise_error(JSON::Api::Vanilla::InvalidRootStructure)
   end
 
-  it "should raise an error if the document has a malformed link" do
+  it "should raise an error if a relationship object does not have one of the required fields" do
     json = <<-JSON
     {
       "data": {


### PR DESCRIPTION
It is common for API consumers hand-crafing responses to not embed relationships in a `data` field. The gem currently interprets this as a `null` object; rather than as malformed.

This simple patch enforces the required fields on a relationship according to the [json:api specification](https://jsonapi.org/format/#document-resource-object-relationships).