### PR TITLE
Normalize hash before parse the objects

### DIFF
--- a/lib/json-api-vanilla/parser.rb
+++ b/lib/json-api-vanilla/parser.rb
@@ -32,6 +32,8 @@ module JSON::Api::Vanilla
   # @param hash [Hash] parsed JSON API payload.
   # @return [JSON::Api::Vanilla::Document] a wrapper for the objects.
   def self.build(hash)
+    hash = normalize_hash(hash)
+
     naive_validate(hash)
     # Object storage.
     container = Module.new
@@ -209,6 +211,19 @@ module JSON::Api::Vanilla
     present_structures = root_keys & hash.keys.map(&:to_sym)
     if present_structures.empty?
       raise InvalidRootStructure.new("JSON:API relationship must contain at least one of these objects: #{root_keys.join(', ')}")
+    end
+  end
+
+  def self.normalize_hash(object)
+    case object
+    when Hash
+      object.each_with_object({}) do |(key, value), result|
+        result[key.to_s] = normalize_hash(value)
+      end
+    when Array
+      object.map { |e| normalize_hash(e) }
+    else
+      object
     end
   end
 

--- a/spec/json-api-vanilla/diff_spec.rb
+++ b/spec/json-api-vanilla/diff_spec.rb
@@ -171,4 +171,78 @@ describe JSON::Api::Vanilla do
       expect(subject.name).to eql(data['attributes']['name'])
     end
   end
+
+  describe '.build(hash)' do
+    context 'with stringified keys' do
+      let(:hash) {
+        {
+          'data' => [
+            {
+              'id' => 'a123',
+              'type' => 'user',
+              'attributes' => {
+                'activated_at' => '2020-06-11'
+              }
+            }
+          ]
+        }
+      }
+      subject { described_class.build(hash) }
+
+      it 'ceates a Document with data' do
+        expect(subject.data).to be_a(Array)
+        expect(subject.data[0].id).to eql(hash['data'][0]['id'])
+        expect(subject.data[0].type).to eql(hash['data'][0]['type'])
+        expect(subject.data[0].activated_at).to eql(hash['data'][0]['attributes']['activated_at'])
+      end
+    end
+
+    context 'with symbolized in keys' do
+      let(:hash) {
+        {
+          data: [
+            {
+              id: 'a123',
+              type: 'user',
+              attributes: {
+                activated_at: '2020-06-11'
+              }
+            }
+          ]
+        }
+      }
+      subject { described_class.build(hash) }
+
+      it 'ceates a Document with data' do
+        expect(subject.data).to be_a(Array)
+        expect(subject.data[0].id).to eql(hash[:data][0][:id])
+        expect(subject.data[0].type).to eql(hash[:data][0][:type])
+        expect(subject.data[0].activated_at).to eql(hash[:data][0][:attributes][:activated_at])
+      end
+    end
+
+  end
+
+  describe '.normalize_hash' do
+    let(:hash) {
+      {
+        'data' => [
+          {
+            id: 1,
+            type: 'user',
+            'attributes' => {
+              'activated_at' => '2020-06-11'
+            }
+          }
+        ]
+      }
+    }
+
+    subject { described_class.normalize_hash(hash) }
+
+    it 'returns hash with stringified keys' do
+      expect(subject['data'][0]['id']).to eql(hash['data'][0][:id])
+      expect(subject['data'][0]['type']).to eql(hash['data'][0][:type])
+    end
+  end
 end


### PR DESCRIPTION
Hi guys. The example for building method is not working properly, it's build Document with nils

see example bellow or test case in branch:

```ruby
[1] pry(main)>
[2] pry(main)>
[3] pry(main)> hash = {
[3] pry(main)*   data: [
[3] pry(main)*     {
[3] pry(main)*       id: 'a123',
[3] pry(main)*       type: 'user',
[3] pry(main)*       attributes: {
[3] pry(main)*         activated_at: '2020-06-11'
[3] pry(main)*       }
[3] pry(main)*     }
[3] pry(main)*   ]
[3] pry(main)* }
=> {:data=>[{:id=>"a123", :type=>"user", :attributes=>{:activated_at=>"2020-06-11"}}]}
[4] pry(main)> JSON::Api::Vanilla.build(hash)
=> #<JSON::Api::Vanilla::Document:0x00007f97e2adaaf8
 @container=#<Module:0x00007f97e2adae68>,
 @data=nil,
 @errors=nil,
 @keys={},
 @links={nil=>nil},
 @meta={nil=>nil},
 @objects={},
 @rel_links={},
 @superclass=#<Class:0x00007f97e2adadf0>>
```